### PR TITLE
feat: Add `Loading` component to `ui/terminal`

### DIFF
--- a/src/lib/components/ui/terminal/index.ts
+++ b/src/lib/components/ui/terminal/index.ts
@@ -1,5 +1,6 @@
 import Root from './terminal.svelte';
 import TypingAnimation from './terminal-typing-animation.svelte';
 import AnimatedSpan from './terminal-animated-span.svelte';
+import Loading from './terminal-loading.svelte';
 
-export { Root, TypingAnimation, AnimatedSpan };
+export { Root, TypingAnimation, AnimatedSpan, Loading };

--- a/src/routes/components/terminal/basic.svelte
+++ b/src/routes/components/terminal/basic.svelte
@@ -5,19 +5,28 @@
 <Terminal.Root class="m-6 max-w-xl" delay={250}>
 	<Terminal.TypingAnimation>&gt; jsrepo add ui/terminal</Terminal.TypingAnimation>
 
-	<Terminal.AnimatedSpan delay={1500} class="text-green-500">
-		<span>✔ Fetched manifest.</span>
-	</Terminal.AnimatedSpan>
+	<Terminal.Loading
+		delay={1500}
+		class="text-blue-400 data-[completed]:text-green-500"
+		loadingMessage="Fetching manifest"
+		completeMessage="Retrieved blocks from github/ieedan/shadcn-svelte-extras"
+	/>
 
-	<Terminal.AnimatedSpan delay={2000} class="text-green-500">
-		<span>✔ Retrieved blocks from github/ieedan/shadcn-svelte-extras</span>
-	</Terminal.AnimatedSpan>
+	<Terminal.Loading
+		delay={2750}
+		class="text-blue-400 data-[completed]:text-green-500"
+		loadingMessage="Adding ui/terminal"
+		completeMessage="Added ui/terminal"
+	/>
 
-	<Terminal.AnimatedSpan delay={2500} class="text-green-500">
-		<span>✔ Added ui/terminal</span>
-	</Terminal.AnimatedSpan>
+	<Terminal.Loading
+		delay={4000}
+		class="text-blue-400 data-[completed]:text-green-500"
+		loadingMessage="Installing dependencies"
+		completeMessage="Installed runed@^0.23.4"
+	/>
 
-	<Terminal.AnimatedSpan delay={3000} class="text-green-500">
+	<Terminal.AnimatedSpan delay={5250} class="text-green-500">
 		<span>✔ All done.</span>
 	</Terminal.AnimatedSpan>
 </Terminal.Root>


### PR DESCRIPTION
Adds a `<Terminal.Loading/>` component to show loading states in the terminal preview component.

Preview:



https://github.com/user-attachments/assets/b6107328-e567-4585-8bd9-66bf7c181a44

