### PR TITLE
add subtree to autoscroll observer

### DIFF
--- a/src/lib/hooks/use-auto-scroll.svelte.ts
+++ b/src/lib/hooks/use-auto-scroll.svelte.ts
@@ -62,7 +62,7 @@ export class UseAutoScroll {
 			this.lastScrollHeight = this.#ref.scrollHeight;
 		});
 
-		observer.observe(this.#ref, { childList: true });
+		observer.observe(this.#ref, { childList: true, subtree: true });
 	}
 
 	get ref() {


### PR DESCRIPTION
add subtree to autoscroll observer since shadcn svelte scroll area class prop does not apply to the children so have to make nested component like this

```svelte
<ScrollArea
	bind:vp={autoScroll.ref}>
	<div class="flex w-full flex-col items-center pb-40 pt-20 gap-4">
		{#each messages as message, index}
			<MessageBlock {message}/>
		{/each}
	</div>
</ScrollArea>
```

without setting subtree to true this scrollarea will not autoscroll when messages are updated