### PR TITLE
breaking(hooks/is-mac.svelte): Export const (`isMac`) instead of class.

### DIFF
--- a/.changeset/salty-pianos-turn.md
+++ b/.changeset/salty-pianos-turn.md
@@ -1,0 +1,5 @@
+---
+'shadcn-svelte-extras': major
+---
+
+breaking(hooks/is-mac.svelte): Export const (`isMac`) instead of class.

--- a/.changeset/shaggy-baboons-bet.md
+++ b/.changeset/shaggy-baboons-bet.md
@@ -1,0 +1,5 @@
+---
+'shadcn-svelte-extras': minor
+---
+
+feat(hooks/is-mac.svelte): Export `cmdOrCtrl` and `optionOrAlt` helpers

--- a/src/lib/components/search-button.svelte
+++ b/src/lib/components/search-button.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { Kbd } from '$lib/components/ui/kbd';
 	import { Button } from '$lib/components/ui/button';
-	import { SearchIcon, CommandIcon } from '@lucide/svelte';
+	import { SearchIcon } from '@lucide/svelte';
 	import { cn } from '$lib/utils/utils';
 	import { commandContext } from '$lib/context';
-	import { IsMac } from '$lib/hooks/is-mac.svelte';
+	import { cmdOrCtrl } from '$lib/hooks/is-mac.svelte';
 
 	type Props = {
 		class?: string;
@@ -13,8 +13,6 @@
 	let { class: className }: Props = $props();
 
 	const commandState = commandContext.get();
-
-	const isMac = new IsMac();
 </script>
 
 <Button
@@ -27,11 +25,6 @@
 		Search
 	</span>
 	<Kbd size="sm" variant="secondary">
-		{#if isMac.current}
-			<CommandIcon class="inline size-3" />
-		{:else}
-			Ctrl
-		{/if}
-		+ K
+		{cmdOrCtrl} + K
 	</Kbd>
 </Button>

--- a/src/lib/hooks/is-mac.svelte.ts
+++ b/src/lib/hooks/is-mac.svelte.ts
@@ -1,6 +1,7 @@
-import { browser } from '$app/environment';
-
 /** Attempts to determine if a user is on a Mac using `navigator.userAgent`. */
-export class IsMac {
-	readonly current = $derived(browser ? navigator.userAgent.includes('Mac') : false);
-}
+export const isMac = navigator.userAgent.includes('Mac');
+
+/** `⌘` for mac or `Ctrl` for windows */
+export const cmdOrCtrl = isMac ? '⌘' : 'Ctrl';
+/** `⌥` for mac or `Alt` for windows */
+export const optionOrAlt = isMac ? '⌥' : 'Alt';

--- a/src/routes/hooks/is-mac/+page.svelte
+++ b/src/routes/hooks/is-mac/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Subheading } from '$lib/components/docs';
+	import { CodeSpan, Subheading } from '$lib/components/docs';
 	import Installation from '$lib/components/installation.svelte';
 	import Playground from '$lib/components/playground.svelte';
 	import Code from '$lib/components/docs/code.svelte';
@@ -15,16 +15,22 @@
 <div>
 	<Code
 		lang="svelte"
-		highlight={[2, 4]}
+		highlight={[2, 5]}
 		code={`\<script lang="ts"\>
-    import { IsMac } from '$lib/hooks/is-mac.svelte.js';
-
-    const isMac = new IsMac();
+    import { isMac } from '$lib/hooks/is-mac.svelte.js';
 \<\/script\>
 
-<p>{isMac.current ? '⌘' : 'Ctrl'}</p>`}
+<p>{isMac ? 'Mac' : 'Not Mac'}</p>`}
 	/>
 </div>
+<Subheading>Keys</Subheading>
+<p>
+	Often times you'll want to show modifier keys in your UI. You can do this with the exported
+	<CodeSpan>cmdOrCtrl</CodeSpan> and <CodeSpan>optionOrAlt</CodeSpan> variables.
+</p>
+<Playground code={examples.keys.code}>
+	<examples.keys.Component />
+</Playground>
 <Subheading>Acknowledgements</Subheading>
 <p>
 	This hook is based on the shadcn-svelte
@@ -33,5 +39,7 @@
 		target="_blank"
 	>
 		useIsMac
-	</Link> hook.
+	</Link> hook, as well as some useful enhancements by <Link href="https://github.com/tglide">
+		Thomas G. Lopes
+	</Link>
 </p>

--- a/src/routes/hooks/is-mac/basic.svelte
+++ b/src/routes/hooks/is-mac/basic.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-	import { IsMac } from '$lib/hooks/is-mac.svelte';
+	import { isMac } from '$lib/hooks/is-mac.svelte';
 	import Mac from './mac.svelte';
 	import NotMac from './not-mac.svelte';
-
-	const isMac = new IsMac();
 </script>
 
-{#if isMac.current}
+{#if isMac}
 	<Mac />
 {:else}
 	<NotMac />

--- a/src/routes/hooks/is-mac/examples.ts
+++ b/src/routes/hooks/is-mac/examples.ts
@@ -1,10 +1,16 @@
 import Basic from './basic.svelte';
 import basicRaw from './basic.svelte?raw';
+import Keys from './keys.svelte';
+import keysRaw from './keys.svelte?raw';
 
 const examples = {
 	basic: {
 		code: basicRaw,
 		Component: Basic
+	},
+	keys: {
+		code: keysRaw,
+		Component: Keys
 	}
 };
 

--- a/src/routes/hooks/is-mac/keys.svelte
+++ b/src/routes/hooks/is-mac/keys.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { cmdOrCtrl, optionOrAlt } from '$lib/hooks/is-mac.svelte';
+	import { Kbd } from '$lib/components/ui/kbd';
+</script>
+
+<div class="flex flex-col place-items-center gap-2">
+	<div class="flex flex-col place-items-center gap-2">
+		<span class="text-muted-foreground text-sm">Command/Ctrl</span>
+		<Kbd variant="secondary">
+			{cmdOrCtrl}
+		</Kbd>
+	</div>
+	<div class="flex flex-col place-items-center gap-2">
+		<span class="text-muted-foreground text-sm">Option/Alt</span>
+		<Kbd variant="secondary">
+			{optionOrAlt}
+		</Kbd>
+	</div>
+</div>


### PR DESCRIPTION
- Export `cmdOrCtrl` and `optionOrAlt` helpers

This came up in a conversation on discord. It's not actually necessary to check whether we are in a browser environment when accessing navigator. Because of this it's less verbose to just export a const. We also add the `cmdOrCtrl` and `optionOrAlt` helpers that were also mentioned in the same conversation.