### PR TITLE
fix(hooks/use-toc.svelte): Improve heading visibility algorithim to make the topmost heading active

### DIFF
--- a/.changeset/tall-zebras-appear.md
+++ b/.changeset/tall-zebras-appear.md
@@ -1,0 +1,5 @@
+---
+'shadcn-svelte-extras': patch
+---
+
+fix(hooks/use-toc.svelte): Improve heading visibility algorithim to make the topmost heading active


### PR DESCRIPTION
Fixes #231 (again) thanks to @mmailaender for the improvements posted in the original issue