### PR TITLE
feat(ui/code): Add `Code.Overflow` component

### DIFF
--- a/.changeset/wet-impalas-jump.md
+++ b/.changeset/wet-impalas-jump.md
@@ -1,0 +1,5 @@
+---
+'shadcn-svelte-extras': minor
+---
+
+feat(ui/code): Add `Code.Overflow` component

--- a/src/lib/components/ui/code/code-overflow.svelte
+++ b/src/lib/components/ui/code/code-overflow.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import Button from '../button/button.svelte';
+	import { useCodeOverflow } from './code.svelte.js';
+	import { box } from 'svelte-toolbelt';
+	import type { CodeOverflowProps } from './types';
+	import { cn } from '$lib/utils/utils';
+
+	let {
+		collapsed = $bindable(true),
+		class: className,
+		children,
+		...props
+	}: CodeOverflowProps = $props();
+
+	const state = useCodeOverflow({
+		collapsed: box.with(
+			() => collapsed,
+			(v) => (collapsed = v)
+		)
+	});
+</script>
+
+<div
+	{...props}
+	data-code-overflow
+	data-collapsed={collapsed}
+	class={cn('relative overflow-y-hidden data-[collapsed=true]:max-h-[300px]', className)}
+>
+	{@render children?.()}
+	{#if collapsed}
+		<div
+			class="from-background absolute bottom-0 left-0 z-10 h-full w-full bg-gradient-to-t to-transparent"
+		></div>
+	{/if}
+	{#if collapsed}
+		<Button
+			variant="secondary"
+			size="sm"
+			class="absolute bottom-2 left-1/2 z-20 w-fit -translate-x-1/2"
+			onclick={state.toggleCollapsed}
+		>
+			Expand
+		</Button>
+	{/if}
+</div>

--- a/src/lib/components/ui/code/code.svelte
+++ b/src/lib/components/ui/code/code.svelte
@@ -51,7 +51,11 @@
 	}
 
 	:global(pre.shiki) {
-		@apply overflow-auto rounded-lg bg-inherit py-4 text-sm;
+		@apply overflow-x-auto rounded-lg bg-inherit py-4 text-sm;
+	}
+
+	:global(pre.shiki:not([data-code-overflow] *):not([data-code-overflow])) {
+		@apply overflow-y-auto;
 		max-height: min(100%, 650px);
 	}
 

--- a/src/lib/components/ui/code/index.ts
+++ b/src/lib/components/ui/code/index.ts
@@ -1,10 +1,11 @@
 import { tv, type VariantProps } from 'tailwind-variants';
 import Root from './code.svelte';
+import Overflow from './code-overflow.svelte';
 import CopyButton from './code-copy-button.svelte';
 import type { CodeCopyButtonProps, CodeRootProps } from './types';
 
 export const codeVariants = tv({
-	base: 'not-prose relative h-full max-h-[650px] overflow-auto rounded-lg border',
+	base: 'not-prose relative h-full overflow-auto rounded-lg border',
 	variants: {
 		variant: {
 			default: 'border-border bg-card',
@@ -18,6 +19,7 @@ export type CodeVariant = VariantProps<typeof codeVariants>['variant'];
 export {
 	Root,
 	CopyButton,
+	Overflow,
 	type CodeRootProps as RootProps,
 	type CodeCopyButtonProps as CopyButtonProps
 };

--- a/src/lib/components/ui/code/types.ts
+++ b/src/lib/components/ui/code/types.ts
@@ -21,3 +21,10 @@ export type CodeCopyButtonPropsWithoutHTML = Omit<CopyButtonPropsWithoutHTML, 't
 
 export type CodeCopyButtonProps = CodeCopyButtonPropsWithoutHTML &
 	WithoutChildren<HTMLAttributes<HTMLButtonElement>>;
+
+export type CodeOverflowPropsWithoutHTML = WithChildren<{
+	collapsed?: boolean;
+}>;
+
+export type CodeOverflowProps = CodeOverflowPropsWithoutHTML &
+	WithoutChildren<HTMLAttributes<HTMLDivElement>>;

--- a/src/lib/docs/api-reference/components/code-api.ts
+++ b/src/lib/docs/api-reference/components/code-api.ts
@@ -1,7 +1,8 @@
 import * as api from '../api-reference';
 import type {
 	CodeRootPropsWithoutHTML,
-	CodeCopyButtonPropsWithoutHTML
+	CodeCopyButtonPropsWithoutHTML,
+	CodeOverflowPropsWithoutHTML
 } from '$lib/components/ui/code/types';
 
 const Root = api.createComponentReference<CodeRootPropsWithoutHTML>({
@@ -85,10 +86,26 @@ const CopyButton = api.createComponentReference<CodeCopyButtonPropsWithoutHTML>(
 	}
 });
 
+const Overflow = api.createComponentReference<CodeOverflowPropsWithoutHTML>({
+	name: 'Overflow',
+	description: 'A component to handle overflow of the code block.',
+	props: {
+		collapsed: api.createBooleanProp({
+			description: 'Whether the code block is collapsed.',
+			defaultValue: true
+		}),
+		children: api.createAnyProp({
+			description: 'Slot content for the overflow component.',
+			type: 'Snippet'
+		})
+	}
+});
+
 export const reference = {
 	name: 'Code' as const,
 	components: {
 		Root,
-		CopyButton
+		CopyButton,
+		Overflow
 	}
 };

--- a/src/routes/components/code/overflow.svelte
+++ b/src/routes/components/code/overflow.svelte
@@ -4,7 +4,9 @@
 </script>
 
 <div class="w-full p-6">
-	<Code.Root lang="svelte" class="w-full" code={codeCode}>
-		<Code.CopyButton />
-	</Code.Root>
+	<Code.Overflow>
+		<Code.Root lang="svelte" code={codeCode}>
+			<Code.CopyButton />
+		</Code.Root>
+	</Code.Overflow>
 </div>


### PR DESCRIPTION
Adds a `Code.Overflow` component to allow for hiding longer blocks of code without the need for scrollbars.

![CleanShot 2025-06-23 at 14 27 10](https://github.com/user-attachments/assets/8fed3e52-6f03-4654-8864-2ea199a134cb)
