### PR TITLE
feat: set initial heading active state to false in table of contents

### DIFF
--- a/.changeset/dirty-papers-smell.md
+++ b/.changeset/dirty-papers-smell.md
@@ -1,0 +1,5 @@
+---
+'shadcn-svelte-extras': patch
+---
+
+ToC - Initialize Headings with active: false to avoid ToC flicker during render

--- a/src/lib/hooks/use-toc.svelte.ts
+++ b/src/lib/hooks/use-toc.svelte.ts
@@ -123,7 +123,7 @@ const createHeading = (element: HTMLHeadingElement, index: number): Heading => {
 		id: element.id,
 		level: parseInt(kind[1]),
 		label: element.innerText ?? '',
-		active: true,
+		active: false,
 		children: []
 	};
 };


### PR DESCRIPTION
Solves: https://github.com/ieedan/shadcn-svelte-extras/issues/251