### PR TITLE
bump vite (repro)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"typescript-eslint": "^8.44.0",
 		"valibot": "1.1.0",
 		"vaul-svelte": "1.0.0-next.7",
-		"vite": "^7.1.5",
+		"vite": "^7.1.6",
 		"yeezy-dates": "^1.0.1"
 	},
 	"pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,16 +56,16 @@ importers:
         version: 3.12.2
       '@sveltejs/adapter-vercel':
         specifier: ^5.10.2
-        version: 5.10.2(@sveltejs/kit@2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(encoding@0.1.13)(rollup@4.46.0)
+        version: 5.10.2(@sveltejs/kit@2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(encoding@0.1.13)(rollup@4.46.0)
       '@sveltejs/kit':
         specifier: ^2.42.1
-        version: 2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
+        version: 2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.0
-        version: 6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
+        version: 6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
       '@tailwindcss/vite':
         specifier: ^4.1.13
-        version: 4.1.13(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
+        version: 4.1.13(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
       '@zxcvbn-ts/core':
         specifier: ^3.0.4
         version: 3.0.4
@@ -143,7 +143,7 @@ importers:
         version: 0.9.3(svelte@5.38.10)
       sveltekit-superforms:
         specifier: ^2.27.1
-        version: 2.27.1(@sveltejs/kit@2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(@types/json-schema@7.0.15)(esbuild@0.25.8)(svelte@5.38.10)(typescript@5.9.2)
+        version: 2.27.1(@sveltejs/kit@2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(@types/json-schema@7.0.15)(esbuild@0.25.8)(svelte@5.38.10)(typescript@5.9.2)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -169,8 +169,8 @@ importers:
         specifier: 1.0.0-next.7
         version: 1.0.0-next.7(svelte@5.38.10)
       vite:
-        specifier: ^7.1.5
-        version: 7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
+        specifier: ^7.1.6
+        version: 7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
       yeezy-dates:
         specifier: ^1.0.1
         version: 1.0.1
@@ -3076,8 +3076,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@7.1.5:
-    resolution: {integrity: sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==}
+  vite@7.1.6:
+    resolution: {integrity: sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4032,9 +4032,9 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-vercel@5.10.2(@sveltejs/kit@2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(encoding@0.1.13)(rollup@4.46.0)':
+  '@sveltejs/adapter-vercel@5.10.2(@sveltejs/kit@2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(encoding@0.1.13)(rollup@4.46.0)':
     dependencies:
-      '@sveltejs/kit': 2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
+      '@sveltejs/kit': 2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
       '@vercel/nft': 0.30.0(encoding@0.1.13)(rollup@4.46.0)
       esbuild: 0.25.8
     transitivePeerDependencies:
@@ -4042,11 +4042,11 @@ snapshots:
       - rollup
       - supports-color
 
-  '@sveltejs/kit@2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))':
+  '@sveltejs/kit@2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -4059,26 +4059,26 @@ snapshots:
       set-cookie-parser: 2.7.1
       sirv: 3.0.1
       svelte: 5.38.10
-      vite: 7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
+      vite: 7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
       debug: 4.4.1
       svelte: 5.38.10
-      vite: 7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
+      vite: 7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))':
+  '@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
       debug: 4.4.1
       deepmerge: 4.3.1
       magic-string: 0.30.19
       svelte: 5.38.10
-      vite: 7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
-      vitefu: 1.1.1(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
+      vite: 7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
+      vitefu: 1.1.1(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -4157,12 +4157,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.13
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.13
 
-  '@tailwindcss/vite@4.1.13(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))':
+  '@tailwindcss/vite@4.1.13(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))':
     dependencies:
       '@tailwindcss/node': 4.1.13
       '@tailwindcss/oxide': 4.1.13
       tailwindcss: 4.1.13
-      vite: 7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
+      vite: 7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
 
   '@tmcp/adapter-valibot@0.1.4(tmcp@1.12.2(typescript@5.9.2))(valibot@1.1.0(typescript@5.9.2))':
     dependencies:
@@ -6003,9 +6003,9 @@ snapshots:
       magic-string: 0.30.19
       zimmerframe: 1.1.2
 
-  sveltekit-superforms@2.27.1(@sveltejs/kit@2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(@types/json-schema@7.0.15)(esbuild@0.25.8)(svelte@5.38.10)(typescript@5.9.2):
+  sveltekit-superforms@2.27.1(@sveltejs/kit@2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(@types/json-schema@7.0.15)(esbuild@0.25.8)(svelte@5.38.10)(typescript@5.9.2):
     dependencies:
-      '@sveltejs/kit': 2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
+      '@sveltejs/kit': 2.42.1(@sveltejs/vite-plugin-svelte@6.2.0(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)))(svelte@5.38.10)(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1))
       devalue: 5.1.1
       memoize-weak: 1.0.2
       svelte: 5.38.10
@@ -6226,7 +6226,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1):
+  vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6240,9 +6240,9 @@ snapshots:
       lightningcss: 1.30.1
       yaml: 2.7.1
 
-  vitefu@1.1.1(vite@7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)):
+  vitefu@1.1.1(vite@7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)):
     optionalDependencies:
-      vite: 7.1.5(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
+      vite: 7.1.6(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
 
   vue@3.5.21(typescript@5.9.2):
     dependencies:


### PR DESCRIPTION
Opening this as a reproduction for the vite team. It must be a weird combination of dependencies that is making this happen cause it's hard to reproduce in a clean slate project.

Any versions of vite>=7.1.6 will break the plugins in the `vite.config.ts` file with the following error:
```
No overload matches this call.
  The last overload gave the following error.
    Type 'Plugin$1<any>[]' is not assignable to type 'PluginOption'.
      Type 'Plugin$1<any>[]' is not assignable to type 'PluginOption[]'.
        Type 'Plugin$1<any>' is not assignable to type 'PluginOption'.
          Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>'.
            Types of property 'hotUpdate' are incompatible.
              Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").ObjectHook<(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, option...' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").ObjectHook<(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, option...'. Two different types with this name exist, but they are unrelated.
                Type '(this: MinimalPluginContext & { environment: DevEnvironment; }, options: HotUpdateOptions) => void | EnvironmentModuleNode[] | Promise<...>' is not assignable to type 'ObjectHook<(this: MinimalPluginContext & { environment: DevEnvironment; }, options: HotUpdateOptions) => void | EnvironmentModuleNode[] | Promise<...>> | undefined'.
                  Type '(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, options: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/nod...' is not assignable to type '(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, options: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/nod...'.
                    Types of parameters 'options' and 'options' are incompatible.
                      Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").HotUpdateOptions' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").HotUpdateOptions'.
                        The types of 'server.config.builder' are incompatible between these types.
                          Type '(import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>) | undefined' is not assignable to type '(import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>) | undefined'.
                            Type 'BuilderOptions & Required<BuilderOptions>' is not assignable to type '(BuilderOptions & Required<BuilderOptions>) | undefined'.
                              Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>'.
                                Type 'BuilderOptions & Required<BuilderOptions>' is not assignable to type 'BuilderOptions'.
                                  Types of property 'buildApp' are incompatible.
                                    Type '(builder: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").ViteBuilder) => Promise<...>' is not assignable to type '(builder: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").ViteBuilder) => Promise<...>'.
                                      Types of parameters 'builder' and 'builder' are incompatible.
                                        Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").ViteBuilder' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").ViteBuilder'.
                                          Types of property 'environments' are incompatible.
                                            Type 'Record<string, import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuildEnvironment>' is not assignable to type 'Record<string, import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuildEnvironment>'.
                                              'string' index signatures are incompatible.
                                                Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuildEnvironment' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuildEnvironment'.
                                                  Types of property 'plugins' are incompatible.
                                                    Type 'readonly import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>[]' is not assignable to type 'readonly import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>[]'.
                                                      Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>'.
                                                        Types of property 'hotUpdate' are incompatible.
                                                          Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").ObjectHook<(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, option...' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").ObjectHook<(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, option...'. Two different types with this name exist, but they are unrelated.
                                                            Type '(this: MinimalPluginContext & { environment: DevEnvironment; }, options: HotUpdateOptions) => void | EnvironmentModuleNode[] | Promise<...>' is not assignable to type 'ObjectHook<(this: MinimalPluginContext & { environment: DevEnvironment; }, options: HotUpdateOptions) => void | EnvironmentModuleNode[] | Promise<...>> | undefined'.
                                                              Type '(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, options: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/nod...' is not assignable to type '(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, options: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/nod...'.
                                                                Types of parameters 'options' and 'options' are incompatible.
                                                                  Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").HotUpdateOptions' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").HotUpdateOptions'.
                                                                    The types of 'server.config.builder' are incompatible between these types.
                                                                      Type '(import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>) | undefined' is not assignable to type '(import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>) | undefined'.
                                                                        Type 'BuilderOptions & Required<BuilderOptions>' is not assignable to type '(BuilderOptions & Required<BuilderOptions>) | undefined'.
                                                                          Type 'Promise<Plugin$1<any>[]>' is not assignable to type 'PluginOption'.
                                                                            Type 'Promise<Plugin$1<any>[]>' is not assignable to type 'Promise<Plugin$1<any> | FalsyPlugin | PluginOption[]>'.
                                                                              Type 'Plugin$1<any>[]' is not assignable to type 'Plugin$1<any> | FalsyPlugin | PluginOption[]'.
                                                                                Type 'Plugin$1<any>[]' is not assignable to type 'PluginOption[]'.
                                                                                  Type 'Plugin$1<any>' is not assignable to type 'PluginOption'.
                                                                                    Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>'.
                                                                                      Types of property 'hotUpdate' are incompatible.
                                                                                        Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").ObjectHook<(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, option...' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").ObjectHook<(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, option...'. Two different types with this name exist, but they are unrelated.
                                                                                          Type '(this: MinimalPluginContext & { environment: DevEnvironment; }, options: HotUpdateOptions) => void | EnvironmentModuleNode[] | Promise<...>' is not assignable to type 'ObjectHook<(this: MinimalPluginContext & { environment: DevEnvironment; }, options: HotUpdateOptions) => void | EnvironmentModuleNode[] | Promise<...>> | undefined'.
                                                                                            Type '(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, options: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/nod...' is not assignable to type '(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, options: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/nod...'.
                                                                                              Types of parameters 'options' and 'options' are incompatible.
                                                                                                Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").HotUpdateOptions' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").HotUpdateOptions'.
                                                                                                  The types of 'server.config.builder' are incompatible between these types.
                                                                                                    Type '(import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>) | undefined' is not assignable to type '(import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>) | undefined'.
                                                                                                      Type 'BuilderOptions & Required<BuilderOptions>' is not assignable to type '(BuilderOptions & Required<BuilderOptions>) | undefined'.
                                                                                                        Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>'.
                                                                                                          Type 'BuilderOptions & Required<BuilderOptions>' is not assignable to type 'BuilderOptions'.
                                                                                                            Types of property 'buildApp' are incompatible.
                                                                                                              Type '(builder: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").ViteBuilder) => Promise<...>' is not assignable to type '(builder: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").ViteBuilder) => Promise<...>'.
                                                                                                                Types of parameters 'builder' and 'builder' are incompatible.
                                                                                                                  Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").ViteBuilder' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").ViteBuilder'.
                                                                                                                    Types of property 'environments' are incompatible.
                                                                                                                      Type 'Record<string, import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuildEnvironment>' is not assignable to type 'Record<string, import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuildEnvironment>'.
                                                                                                                        'string' index signatures are incompatible.
                                                                                                                          Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuildEnvironment' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuildEnvironment'.
                                                                                                                            Types of property 'plugins' are incompatible.
                                                                                                                              Type 'readonly import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>[]' is not assignable to type 'readonly import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>[]'.
                                                                                                                                Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").Plugin<any>'.
                                                                                                                                  Types of property 'hotUpdate' are incompatible.
                                                                                                                                    Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").ObjectHook<(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, option...' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").ObjectHook<(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, option...'. Two different types with this name exist, but they are unrelated.
                                                                                                                                      Type '(this: MinimalPluginContext & { environment: DevEnvironment; }, options: HotUpdateOptions) => void | EnvironmentModuleNode[] | Promise<...>' is not assignable to type 'ObjectHook<(this: MinimalPluginContext & { environment: DevEnvironment; }, options: HotUpdateOptions) => void | EnvironmentModuleNode[] | Promise<...>> | undefined'.
                                                                                                                                        Type '(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, options: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/nod...' is not assignable to type '(this: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/rollup@4.46.0/node_modules/rollup/dist/rollup").MinimalPluginContext & { ...; }, options: import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/nod...'.
                                                                                                                                          Types of parameters 'options' and 'options' are incompatible.
                                                                                                                                            Type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").HotUpdateOptions' is not assignable to type 'import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").HotUpdateOptions'.
                                                                                                                                              The types of 'server.config.builder' are incompatible between these types.
                                                                                                                                                Type '(import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.7_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>) | undefined' is not assignable to type '(import("C:/Users/ablesea/Documents/GitHub/shadcn-svelte-extras/node_modules/.pnpm/vite@7.1.5_jiti@2.5.1_lightningcss@1.30.1_yaml@2.7.1/node_modules/vite/dist/node/index").BuilderOptions & Required<...>) | undefined'.
                                                                                                                                                  Type 'BuilderOptions & Required<BuilderOptions>' is not assignable to type '(BuilderOptions & Required<BuilderOptions>) | undefined'.ts(2769)
index.d.ts(3057, 18): The last overload is declared here.
```

<img width="1609" height="779" alt="image" src="https://github.com/user-attachments/assets/8845dda4-1cfb-415b-8c7c-5e7a19673d34" />


I have also seen this on other projects.