### PR TITLE
FIx: Prevent submit behaviour onCancel

### DIFF
--- a/src/lib/components/ui/confirm-delete-dialog/confirm-delete-dialog.svelte
+++ b/src/lib/components/ui/confirm-delete-dialog/confirm-delete-dialog.svelte
@@ -112,7 +112,7 @@
 				/>
 			{/if}
 			<AlertDialog.Footer>
-				<AlertDialog.Cancel onclick={dialogState.cancel}>
+				<AlertDialog.Cancel type="button" onclick={dialogState.cancel}>
 					{dialogState.options?.cancel?.text ?? 'Cancel'}
 				</AlertDialog.Cancel>
 				<AlertDialog.Action


### PR DESCRIPTION
We need to add `type='button'` on the `AlertDialog.Cancel` to prevent form submission when user clicks `Cancel` button.