### PR TITLE
docs(installation): fix config filename from .json to .config.ts

### DIFF
--- a/src/routes/(app)/docs/installation/+page.svelte
+++ b/src/routes/(app)/docs/installation/+page.svelte
@@ -16,8 +16,8 @@
 <p>Initialize jsrepo with shadcn-svelte-extras:</p>
 <JsrepoCommand command="execute" args={['jsrepo', 'init', '@ieedan/shadcn-svelte-extras']} />
 <p>
-	Configure the <CodeSpan>paths</CodeSpan> key in your <CodeSpan>jsrepo.config.ts</CodeSpan> file so that
-	components, hooks, and utils are added to the correct places:
+	Configure the <CodeSpan>paths</CodeSpan> key in your <CodeSpan>jsrepo.config.ts</CodeSpan> file so
+	that components, hooks, and utils are added to the correct places:
 </p>
 <div>
 	<Code


### PR DESCRIPTION
The installation docs reference `jsrepo.json` but show TypeScript code with `defineConfig()` syntax, which is the format for `jsrepo.config.ts`.

This fixes the inconsistency by changing the filename reference from `jsrepo.json` to `jsrepo.config.ts`.