### PR TITLE
fix(file-drop-zone): Ensure `accept` handles extension patterns correctly

### DIFF
--- a/.changeset/ripe-doodles-shave.md
+++ b/.changeset/ripe-doodles-shave.md
@@ -1,0 +1,5 @@
+---
+'shadcn-svelte-extras': patch
+---
+
+fix(file-drop-zone): Ensure `accept` handles extension patterns correctly

--- a/src/lib/components/ui/file-drop-zone/file-drop-zone.svelte.ts
+++ b/src/lib/components/ui/file-drop-zone/file-drop-zone.svelte.ts
@@ -74,7 +74,7 @@ class FileDropZoneState {
 
 		const isAcceptable = acceptedTypes.some((pattern) => {
 			// check extension like .mp4
-			if (fileType.startsWith('.')) {
+			if (fileType === '' || pattern.startsWith('.')) {
 				return fileName.endsWith(pattern);
 			}
 


### PR DESCRIPTION
Obviously a misunderstanding of what file.type would be in situations where the mime type isn't detected. Fixes #338 