### PR TITLE
fix(CopyButton): preserve copy handler when used as a Tooltip.Trigger child

### DIFF
--- a/.changeset/copy-button-tooltip-fix.md
+++ b/.changeset/copy-button-tooltip-fix.md
@@ -1,0 +1,5 @@
+---
+'shadcn-svelte-extras': patch
+---
+
+fix(CopyButton): compose `onclick` with spread props so wrappers like `Tooltip.Trigger` no longer override the copy handler (fixes broken copy in `PMCommand` and `JsrepoCommand`)

--- a/src/lib/components/ui/copy-button/copy-button.svelte
+++ b/src/lib/components/ui/copy-button/copy-button.svelte
@@ -22,6 +22,7 @@
 	import Button from '$lib/components/button.svelte';
 	import { UseClipboard } from '$lib/hooks/use-clipboard.svelte';
 	import { cn } from '$lib/utils.js';
+	import { mergeProps } from 'bits-ui';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import CopyIcon from '@lucide/svelte/icons/copy';
 	import XIcon from '@lucide/svelte/icons/x';
@@ -48,6 +49,16 @@
 	}
 
 	const clipboard = new UseClipboard();
+
+	const merged = $derived(
+		mergeProps(rest, {
+			onclick: async () => {
+				const status = await clipboard.copy(text);
+
+				onCopy?.(status);
+			}
+		})
+	);
 </script>
 
 <Button
@@ -58,12 +69,7 @@
 	class={cn('flex items-center gap-2', className)}
 	type="button"
 	name="copy"
-	onclick={async () => {
-		const status = await clipboard.copy(text);
-
-		onCopy?.(status);
-	}}
-	{...rest as /* eslint-disable-line @typescript-eslint/no-explicit-any */ any}
+	{...merged as /* eslint-disable-line @typescript-eslint/no-explicit-any */ any}
 >
 	{#if clipboard.status === 'success'}
 		<div in:scale={{ duration: animationDuration, start: 0.85 }}>


### PR DESCRIPTION
When `CopyButton` was used as a `Tooltip.Trigger` child, the trigger's spread props included an `onclick` that overrode the copy handler — clicking the copy button in `PMCommand` (and `JsrepoCommand`) did nothing.

Use `mergeProps` from `bits-ui` so spread `onclick` handlers are composed instead of overwritten.

https://claude.ai/code/session_01DG17spUYnAeWvVh2k6bCfC