### PR TITLE
fix(use-auto-scroll): clean up listeners and disconnect observer

### DIFF
--- a/.changeset/use-auto-scroll-cleanup.md
+++ b/.changeset/use-auto-scroll-cleanup.md
@@ -1,0 +1,5 @@
+---
+'shadcn-svelte-extras': patch
+---
+
+fix(use-auto-scroll): clean up scroll/resize listeners and disconnect the MutationObserver on unmount or ref rebind by routing through `useEventListener` and `useMutationObserver` from `runed`

--- a/src/lib/hooks/use-auto-scroll.svelte.ts
+++ b/src/lib/hooks/use-auto-scroll.svelte.ts
@@ -1,3 +1,6 @@
+import { untrack } from 'svelte';
+import { useEventListener, useMutationObserver } from 'runed';
+
 /** Use this on a vertically scrollable container to ensure that it automatically scrolls to the bottom of the content.
  *
  * ## Usage
@@ -28,41 +31,56 @@ export class UseAutoScroll {
 	#userHasScrolled = $state(false);
 	private lastScrollHeight = 0;
 
-	// This sets everything up once #ref is bound
-	set ref(ref: HTMLElement | undefined) {
-		this.#ref = ref;
+	constructor() {
+		// Position the container when the ref binds or rebinds
+		$effect(() => {
+			const el = this.#ref;
+			if (!el) return;
 
-		if (!this.#ref) return;
-
-		this.lastScrollHeight = this.#ref.scrollHeight;
-
-		// start from bottom or start position
-		this.#ref.scrollTo(0, this.#scrollY ? this.#scrollY : this.#ref.scrollHeight);
-
-		this.#ref.addEventListener('scroll', () => {
-			if (!this.#ref) return;
-
-			this.#scrollY = this.#ref.scrollTop;
-
-			this.disableAutoScroll();
+			untrack(() => {
+				this.lastScrollHeight = el.scrollHeight;
+				el.scrollTo(0, this.#scrollY ? this.#scrollY : el.scrollHeight);
+			});
 		});
 
-		window.addEventListener('resize', () => {
-			this.scrollToBottom(true);
-		});
+		useEventListener(
+			() => this.#ref,
+			'scroll',
+			() => {
+				if (!this.#ref) return;
 
-		// should detect when something changed that effected the scroll height
-		const observer = new MutationObserver(() => {
-			if (!this.#ref) return;
+				this.#scrollY = this.#ref.scrollTop;
 
-			if (this.#ref.scrollHeight !== this.lastScrollHeight) {
+				this.disableAutoScroll();
+			}
+		);
+
+		useEventListener(
+			() => (this.#ref ? window : null),
+			'resize',
+			() => {
 				this.scrollToBottom(true);
 			}
+		);
 
-			this.lastScrollHeight = this.#ref.scrollHeight;
-		});
+		// should detect when something changed that effected the scroll height
+		useMutationObserver(
+			() => this.#ref,
+			() => {
+				if (!this.#ref) return;
 
-		observer.observe(this.#ref, { childList: true, subtree: true });
+				if (this.#ref.scrollHeight !== this.lastScrollHeight) {
+					this.scrollToBottom(true);
+				}
+
+				this.lastScrollHeight = this.#ref.scrollHeight;
+			},
+			{ childList: true, subtree: true }
+		);
+	}
+
+	set ref(ref: HTMLElement | undefined) {
+		this.#ref = ref;
 	}
 
 	get ref() {

--- a/src/lib/hooks/use-auto-scroll.svelte.ts
+++ b/src/lib/hooks/use-auto-scroll.svelte.ts
@@ -63,7 +63,7 @@ export class UseAutoScroll {
 			}
 		);
 
-		// should detect when something changed that effected the scroll height
+		// should detect when something changed that affected the scroll height
 		useMutationObserver(
 			() => this.#ref,
 			() => {


### PR DESCRIPTION
Closes #390

set ref() attached the scroll, resize and MutationObserver handlers but never removed them. Re-binding ref stacked another set on top of the old one and unmount left everything attached.

Setup is now in the constructor, with the scroll/resize listeners going through useEventListener and the observer going through useMutationObserver. Each one re-binds when ref changes and disconnects on unmount. The initial scrollTo and lastScrollHeight write live in an $effect that depends on #ref, so they re-run on every rebind.

Verified: pnpm check is clean (0 errors), pnpm registry:build succeeds.