### PR TITLE
a few component fixes

### DIFF
--- a/.changeset/eager-apples-cheer.md
+++ b/.changeset/eager-apples-cheer.md
@@ -1,0 +1,5 @@
+---
+'shadcn-svelte-extras': patch
+---
+
+fix: Hide other icons when the `<Button/>` is loading

--- a/.changeset/lucky-clouds-glow.md
+++ b/.changeset/lucky-clouds-glow.md
@@ -1,0 +1,5 @@
+---
+'shadcn-svelte-extras': patch
+---
+
+fix: Remove `tabindex={-1}` for `<CopyButton/>`

--- a/.changeset/shy-apples-smile.md
+++ b/.changeset/shy-apples-smile.md
@@ -1,0 +1,5 @@
+---
+'shadcn-svelte-extras': patch
+---
+
+fix: Fix tab behavior on `<IPV4AddressInput/>`

--- a/src/lib/components/button.svelte
+++ b/src/lib/components/button.svelte
@@ -40,6 +40,7 @@
 <script lang="ts">
 	import { Button, type ButtonProps as ButtonPrimitiveProps } from '$lib/components/ui/button';
 	import { Spinner } from '$lib/components/ui/spinner';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -47,6 +48,7 @@
 		onClickPromise,
 		onclick,
 		disabled,
+		class: className,
 		children,
 		...restProps
 	}: ButtonProps = $props();
@@ -58,6 +60,7 @@
 
 <Button
 	bind:ref
+	class={cn(loading && '[&_svg:not([data-loading-icon])]:hidden', className)}
 	disabled={loading || disabled}
 	onclick={async (e) => {
 		onclick?.(e as never);
@@ -74,7 +77,7 @@
 	{...restProps}
 >
 	{#if loading}
-		<Spinner data-icon="inline-start" />
+		<Spinner data-icon="inline-start" data-loading-icon />
 	{/if}
 	{@render children?.()}
 </Button>

--- a/src/lib/components/docs/examples/code-block.svelte
+++ b/src/lib/components/docs/examples/code-block.svelte
@@ -18,7 +18,7 @@
 				src/routes/+layout.svelte
 			</span>
 		</div>
-		<CopyButton text={code} class="size-7" />
+		<CopyButton text={code} tabindex={-1} class="size-7" />
 	</div>
 	<Code.Root lang="svelte" class="border-none" {code} highlight={[2, 5]} />
 </div>

--- a/src/lib/components/docs/jsrepo-command.svelte
+++ b/src/lib/components/docs/jsrepo-command.svelte
@@ -80,7 +80,7 @@
 		<Tooltip.Root>
 			<Tooltip.Trigger>
 				{#snippet child({ props })}
-					<CopyButton {...props} text={commandText} class="size-6 [&_svg]:size-3">
+					<CopyButton {...props} text={commandText} tabindex={-1} class="size-6 [&_svg]:size-3">
 						{#snippet icon()}
 							<ClipboardIcon />
 						{/snippet}

--- a/src/lib/components/ui/code/code-copy-button.svelte
+++ b/src/lib/components/ui/code/code-copy-button.svelte
@@ -19,6 +19,7 @@
 	bind:ref
 	class={cn('absolute top-2 right-2', className)}
 	text={copyButton.code}
+	tabindex={-1}
 	{variant}
 	{size}
 	{...rest}

--- a/src/lib/components/ui/copy-button/copy-button.svelte
+++ b/src/lib/components/ui/copy-button/copy-button.svelte
@@ -2,7 +2,7 @@
 	import type { Snippet } from 'svelte';
 	import type { ButtonProps } from '$lib/components/ui/button';
 	import type { HTMLAttributes } from 'svelte/elements';
-	import type { WithChildren, WithoutChildren } from 'bits-ui';
+	import { type WithChildren, type WithoutChildren } from 'bits-ui';
 
 	export type CopyButtonPropsWithoutHTML = WithChildren<
 		Pick<ButtonProps, 'size' | 'variant'> & {
@@ -37,7 +37,7 @@
 		size = 'icon',
 		onCopy,
 		class: className,
-		tabindex = -1,
+		tabindex,
 		children,
 		...rest
 	}: CopyButtonProps = $props();
@@ -50,8 +50,11 @@
 
 	const clipboard = new UseClipboard();
 
-	const merged = $derived(
+	const mergedProps = $derived(
 		mergeProps(rest, {
+			variant,
+			size, 
+			tabindex,
 			onclick: async () => {
 				const status = await clipboard.copy(text);
 
@@ -63,13 +66,10 @@
 
 <Button
 	bind:ref
-	{variant}
-	{size}
-	{tabindex}
 	class={cn('flex items-center gap-2', className)}
 	type="button"
 	name="copy"
-	{...merged as /* eslint-disable-line @typescript-eslint/no-explicit-any */ any}
+	{...mergedProps as unknown as ButtonProps}
 >
 	{#if clipboard.status === 'success'}
 		<div in:scale={{ duration: animationDuration, start: 0.85 }}>

--- a/src/lib/components/ui/copy-button/copy-button.svelte
+++ b/src/lib/components/ui/copy-button/copy-button.svelte
@@ -2,7 +2,7 @@
 	import type { Snippet } from 'svelte';
 	import type { ButtonProps } from '$lib/components/ui/button';
 	import type { HTMLAttributes } from 'svelte/elements';
-	import { type WithChildren, type WithoutChildren } from 'bits-ui';
+	import type { WithChildren, WithoutChildren } from 'bits-ui';
 
 	export type CopyButtonPropsWithoutHTML = WithChildren<
 		Pick<ButtonProps, 'size' | 'variant'> & {
@@ -50,11 +50,8 @@
 
 	const clipboard = new UseClipboard();
 
-	const mergedProps = $derived(
+	const merged = $derived(
 		mergeProps(rest, {
-			variant,
-			size, 
-			tabindex,
 			onclick: async () => {
 				const status = await clipboard.copy(text);
 
@@ -66,10 +63,13 @@
 
 <Button
 	bind:ref
+	{variant}
+	{size}
+	{tabindex}
 	class={cn('flex items-center gap-2', className)}
 	type="button"
 	name="copy"
-	{...mergedProps as unknown as ButtonProps}
+	{...merged as unknown as ButtonProps}
 >
 	{#if clipboard.status === 'success'}
 		<div in:scale={{ duration: animationDuration, start: 0.85 }}>

--- a/src/lib/components/ui/ipv4address-input/ipv4address-input.svelte
+++ b/src/lib/components/ui/ipv4address-input/ipv4address-input.svelte
@@ -93,6 +93,7 @@
 	<span class="font-mono">{separator}</span>
 	<Input
 		bind:ref={secondInput}
+		tabindex={-1}
 		goNext={() => thirdInput?.focus()}
 		goPrevious={() => firstInput?.focus()}
 		bind:value={
@@ -115,6 +116,7 @@
 	<span class="font-mono">{separator}</span>
 	<Input
 		bind:ref={thirdInput}
+		tabindex={-1}
 		goNext={() => fourthInput?.focus()}
 		goPrevious={() => secondInput?.focus()}
 		bind:value={
@@ -137,6 +139,7 @@
 	<span class="font-mono">{separator}</span>
 	<Input
 		bind:ref={fourthInput}
+		tabindex={-1}
 		goPrevious={() => thirdInput?.focus()}
 		bind:value={
 			() => octets[3],
@@ -156,4 +159,4 @@
 		onpaste={paste}
 	/>
 </div>
-<input class="hidden" {name} {value} />
+<input class="hidden" tabindex={-1} {name} {value} />

--- a/src/lib/components/ui/pm-command/pm-command.svelte
+++ b/src/lib/components/ui/pm-command/pm-command.svelte
@@ -67,7 +67,7 @@
 			<Tooltip.Root>
 				<Tooltip.Trigger>
 					{#snippet child({ props })}
-						<CopyButton {...props} text={commandText} class="size-6 [&_svg]:size-3">
+						<CopyButton {...props} text={commandText} tabindex={-1} class="size-6 [&_svg]:size-3">
 							{#snippet icon()}
 								<ClipboardIcon />
 							{/snippet}


### PR DESCRIPTION
- Remove `tabindex={-1}` for `<CopyButton/>`
- Fix tab behavior on `<IPV4AddressInput/>`
- Hide other icons when the `<Button/>` is loading